### PR TITLE
Add systemd socket activation support

### DIFF
--- a/systemd/torch.service
+++ b/systemd/torch.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Torch prometheus proxy
+
+[Service]
+ExecStart=/usr/bin/python -m torch
+User=torch
+Restart=always
+
+# Sandboxing:
+PrivateTmp=true
+DevicePolicy=closed
+ProtectSystem=full
+ProtectHome=true
+InaccessibleDirectories=/var /sysroot /run
+ReadOnlyDirectories=/
+PrivateNetwork=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/torch.socket
+++ b/systemd/torch.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=Torch prometheus proxy socket
+
+[Socket]
+ListenStream=/run/torch.sock
+
+[Install]
+WantedBy=sockets.target

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -4,19 +4,25 @@ def main():
 	import os
 	from datetime import timedelta
 	from gevent import wsgi
+	import gevent.socket as socket
 	from .collector import PrometheusMetricCollector
 	class QuietWSGIHandler(wsgi.WSGIHandler):
 		"""WSGIHandler subclass that will not create an access log"""
 		def log_request(self, *args):
 			pass
 
-	port = int(os.environ['SERVICE_PORT'])
+	if os.environ.get('LISTEN_FDS') == '1' and \
+			os.environ.get('LISTEN_PID') == str(os.getpid()):
+		listener = socket.fromfd(3, socket.AF_UNIX, socket.SOCK_STREAM)
+	else:
+		listener = ('0.0.0.0', int(os.environ['SERVICE_PORT']))
+
 	ttl = timedelta(hours=int(os.environ.get('TORCH_TTL', 24)))
 	metrics_prefix = '/metrics'
 
 	application = PrometheusMetricCollector(prefix=metrics_prefix, ttl=ttl)
 
-	httpd = wsgi.WSGIServer(('0.0.0.0', port), application, handler_class=QuietWSGIHandler)
+	httpd = wsgi.WSGIServer(listener, application, handler_class=QuietWSGIHandler)
 	try:
 		httpd.serve_forever()
 	except:


### PR DESCRIPTION
With this the socket that torch will be listening on is opened before
torch is started and passed in.  This is more flexible because the
socket no longer needs to be SOCK_INET.  We'll be using a unix domain
socket.  It also simplifies startup as I can choose to bind mount this
unix socket into containers before torch has started.

To test this out run:

    systemd-socket-activate -l 127.0.0.1:7654 python -m torch

and torch will be listening on http://localhost:7654 .

Systemd unit files are provided for reference.